### PR TITLE
Adding particles to drainlife spell

### DIFF
--- a/src/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
+++ b/src/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
@@ -35,6 +35,7 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 	private boolean instant;
 	private boolean ignoreArmor;
 	private boolean checkPlugins;
+	private String particles;
 	
 	public DrainlifeSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
@@ -49,6 +50,7 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 		instant = getConfigBoolean("instant", true);
 		ignoreArmor = getConfigBoolean("ignore-armor", false);
 		checkPlugins = getConfigBoolean("check-plugins", true);
+		particles = getConfigString("particle", "smoke")
 	}
 	
 	@Override
@@ -202,7 +204,7 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 			Vector tempVector = current.clone();
 			tempVector.subtract(caster.getLocation().toVector()).normalize();
 			current.subtract(tempVector);
-			world.playEffect(current.toLocation(world), Effect.SMOKE, 4);
+			MagicSpells.getVolatileCodeHandler().playParticleEffect(current.toLocation(world), particle, 0, (float) 0.1, 0, 5, 256, (float) 0.5);
 			if (current.distanceSquared(targetVector) < 4 || tick > range * 1.5) {
 				stop();
 				if (!instant) {


### PR DESCRIPTION
I found a way to add different particles into the drainlife spell, and as a bonus, the particle animation looks a lot more smooth.  It uses the volatile code from the spell effects particles method, so it is not the best way to implement this.
https://github.com/BirdmasterLance/MagicSpells/commit/94112a216011dc2a3de9add0e016e9de3ae2ba9f <- Just in case?
(I think this pull request is correct)
